### PR TITLE
Pass along parameters to star (run.bat)

### DIFF
--- a/run.bat
+++ b/run.bat
@@ -2,4 +2,4 @@
 
 IF "%CONFIGURATION%"=="" SET CONFIGURATION=Debug
 
-star --resourcedir="%~dp0src\HelloWorld\wwwroot" "%~dp0src/HelloWorld/bin/%CONFIGURATION%/HelloWorld.exe"
+star %* --resourcedir="%~dp0src\HelloWorld\wwwroot" "%~dp0src/HelloWorld/bin/%CONFIGURATION%/HelloWorld.exe"


### PR DESCRIPTION
Pass along parameters to star (run.bat); for Starcounter/Guidelines#31 .